### PR TITLE
[Toggle] Fix correct answer in toggle – Energy Q3 Hardware Q1 Climate Q4

### DIFF
--- a/docs/practitioner/climate-commitments.mdx
+++ b/docs/practitioner/climate-commitments.mdx
@@ -258,7 +258,7 @@ Carbon aware computing helps organizations increase their CFE percentage.
       answers: [
         {
           text: "SBTi",
-          isCorrect: false,
+          isCorrect: true,
         },
         {
           text: "STBi",
@@ -267,10 +267,6 @@ Carbon aware computing helps organizations increase their CFE percentage.
         {
           text: "STIB",
           isCorrect: false,
-        },
-        {
-          text: "SBTi",
-          isCorrect: true,
         },
       ],
     },

--- a/docs/practitioner/energy-efficiency.mdx
+++ b/docs/practitioner/energy-efficiency.mdx
@@ -127,9 +127,9 @@ Servers are usually not configured for aggressive or even minimal power saving. 
         { text: "Energy that comes from renewable sources", isCorrect: false },
         {
           text: "Energy that doesn’t produce carbon emissions",
-          isCorrect: false,
+          isCorrect: true,
         },
-        { text: "Both the above", isCorrect: true },
+        { text: "Both the above", isCorrect: false },
       ],
     },
     {

--- a/docs/practitioner/energy-efficiency.mdx
+++ b/docs/practitioner/energy-efficiency.mdx
@@ -124,12 +124,12 @@ Servers are usually not configured for aggressive or even minimal power saving. 
     {
       question: "What is clean energy?",
       answers: [
-        { text: "Energy that comes from renewable sources", isCorrect: true },
+        { text: "Energy that comes from renewable sources", isCorrect: false },
         {
           text: "Energy that doesn’t produce carbon emissions",
-          isCorrect: true,
+          isCorrect: false,
         },
-        { text: "Both the above", isCorrect: false },
+        { text: "Both the above", isCorrect: true },
       ],
     },
     {

--- a/docs/practitioner/hardware-efficiency.mdx
+++ b/docs/practitioner/hardware-efficiency.mdx
@@ -89,11 +89,11 @@ It’s important to note that simply moving operations to the public cloud will 
         },
         {
           text: "The carbon emissions associated with both the creation and disposal of a device",
-          isCorrect: false,
+          isCorrect: true,
         },
         {
           text: "The carbon emissions associated with the disposal of a device",
-          isCorrect: true,
+          isCorrect: false,
         },
       ],
     },


### PR DESCRIPTION
Need to review and update toggle settings
- Energy Efficiency Q3 (correct answer not indicated properly) 
- Hardware Efficiency Q1 (correct answer not indicated properly) 
- Climate Commitments Q4 (answer option duplicated)