### PR TITLE
Updates to glossary

### DIFF
--- a/docs/practitioner/glossery.md
+++ b/docs/practitioner/glossery.md
@@ -177,14 +177,6 @@ sidebar_position: 7
    </td>
   </tr>
   <tr>
-   <td><strong>kilowatt hours</strong>
-   </td>
-   <td><strong>kWh</strong>
-   </td>
-   <td>Energy consumption is measured in <strong>kilowatt hours (kWh).</strong> 
-   </td>
-  </tr>
-  <tr>
    <td><strong>grams of carbon per kilowatt hour</strong>
    </td>
    <td><strong>gCO2eq/kWh</strong>


### PR DESCRIPTION
Changes suggested by the Linux Foundation
- kwh was duplicated in the table, we removed the second one from the course content (updates to the website are included in this PR)
- we will put this table in alphabetical order in the course and we'll have the acronyms in the first column (might not be necessary to update the website TBD)
- there is a typo in the file name 'glossery', unsure if I can simply just rename the file. please process this edit as needed.