### PR TITLE
fix: broken link to Github repository

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -80,7 +80,7 @@ const config = {
             items: [
               {
                 label: "Github",
-                href: "https://github.com/Green-Software-Foundation/learn/",
+                href: "https://github.com/Green-Software-Foundation/training/",
               },
               {
                 label: "Website",


### PR DESCRIPTION
Hi, this small PR fixes the broken link to Github repository in the footer:
Old link: https://github.com/Green-Software-Foundation/learn/
Replaced by: https://github.com/Green-Software-Foundation/training/