### PR TITLE
Add exam url to text

### DIFF
--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -8,7 +8,7 @@ Do you want to be a part of the green software movement?
 
 If you want to make your software applications more sustainable and build a career in green software, then this training is for you. It will teach you how to build, maintain and run greener applications irrespective of the application domain, industry, organization size or type, programming language, or framework.
 
-If you pass the associated exam, it comes with a certificate of completion from the Linux Foundation.
+If you pass the [associated exam](https://grnsft.org/practitioner/lf-exam), it comes with a certificate of completion from the Linux Foundation.
 
 ## What is a software practitioner?
 


### PR DESCRIPTION
I suggest we add the url of the linux exam page to the text as well. So if someones starts reading the text and doesn't notice the button in the top right corner, they will still be able to understand that they have to take the exam on another website.