### PR TITLE
Correct course and project name

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -57,9 +57,9 @@ const config = {
     ({
       navbar: {
         // Change to project name
-        title: "Green Software Practitioner",
+        title: "Green Software for Practitioners",
         logo: {
-          alt: "Green Software Practitioner Logo",
+          alt: "Green Software for Practitioners Logo",
           src: "img/logo.svg",
         },
         items: [{
@@ -134,7 +134,7 @@ const config = {
       },
       {
         name: "twitter:title",
-        content: "Green Software Practitioner",
+        content: "Green Software for Practitioners",
       },
       {
         name: "twitter:description",
@@ -150,7 +150,7 @@ const config = {
       },
       {
         name: "og:title",
-        content: "Green Software Practitioner",
+        content: "Green Software for Practitioners",
       },
       {
         name: "og:description",
@@ -166,7 +166,7 @@ const config = {
       },
       {
         name: "og:site_name",
-        content: "Green Software Practitioner",
+        content: "Green Software for Practitioners",
       },
       {
         name: "og:type",


### PR DESCRIPTION
@jawache when reviewing the annual report, I figured that we were using 'Green Software Practitioner' as the project name although the course title is 'Green Software for Practitioners'. Can we switch to the latter everywhere on the website?